### PR TITLE
bug修复

### DIFF
--- a/src/components/SeamlessScroll/src/SeamlessScroll.vue
+++ b/src/components/SeamlessScroll/src/SeamlessScroll.vue
@@ -188,7 +188,8 @@ export default defineComponent({
     });
 
     let scrollSwitch = computed(() => {
-      return data.length >= unref(options).limitMoveNum;
+      // 从 props 解构出来的 属性 不再具有相应性. 
+      return props.data.length >= unref(options).limitMoveNum;
     });
 
     let hoverStopSwitch = computed(() => {


### PR DESCRIPTION
如果初始值是空数组, 通过动态获取数据后仍然不能触发滚动.
原因是因为data 从 props解构出来后不再是一个响应性变量.