### PR TITLE
fix: process.env.node_env undefined

### DIFF
--- a/build/utils.ts
+++ b/build/utils.ts
@@ -1,41 +1,32 @@
-import * as dotenv from "dotenv";
-
-export interface ViteEnv {
-  VITE_PORT: number;
-  VITE_OPEN: boolean;
-  VITE_USE_MOCK: boolean;
-  VITE_PUBLIC_PATH: string;
-  VITE_PROXY: [string, string][];
-}
-
-export function loadEnv(): ViteEnv {
-  const env = process.env.NODE_ENV;
+const warpperEnv = (envConf: Recordable): ViteEnv => {
   const ret: any = {};
-  // eslint-disable-next-line no-sparse-arrays
-  const envList = [`.env.${env}.local`, `.env.${env}`, ".env.local", ".env", ,];
-  envList.forEach(e => {
-    dotenv.config({
-      path: e
-    });
-  });
-  for (const envName of Object.keys(process.env)) {
-    let realName = (process.env as any)[envName].replace(/\\n/g, "\n");
+
+  for (const envName of Object.keys(envConf)) {
+    let realName = envConf[envName].replace(/\\n/g, "\n");
     realName =
       realName === "true" ? true : realName === "false" ? false : realName;
+
     if (envName === "VITE_PORT") {
       realName = Number(realName);
     }
-    if (envName === "VITE_OPEN") {
-      realName = Boolean(realName);
-    }
-    if (envName === "VITE_PROXY") {
+    if (envName === "VITE_PROXY" && realName) {
       try {
-        realName = JSON.parse(realName);
-        // eslint-disable-next-line no-empty
-      } catch (error) {}
+        realName = JSON.parse(realName.replace(/'/g, '"'));
+      } catch (error) {
+        realName = "";
+      }
     }
     ret[envName] = realName;
-    process.env[envName] = realName;
+    if (typeof realName === "string") {
+      process.env[envName] = realName;
+    } else if (typeof realName === "object") {
+      process.env[envName] = JSON.stringify(realName);
+    }
   }
   return ret;
-}
+};
+const loadEnv = (): ViteEnv => {
+  return import.meta.env;
+};
+
+export { loadEnv, warpperEnv };

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -63,7 +63,7 @@ declare global {
     __: unknown;
   }
 
-  interface ViteEnv {
+  declare interface ViteEnv {
     VITE_PORT: number;
     VITE_USE_MOCK: boolean;
     VITE_USE_PWA: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import { resolve } from "path";
-import { UserConfigExport, ConfigEnv } from "vite";
+import { UserConfigExport, ConfigEnv, loadEnv } from "vite";
 import vue from "@vitejs/plugin-vue";
 import vueJsx from "@vitejs/plugin-vue-jsx";
-import { loadEnv } from "./build/utils";
+import { warpperEnv } from "./build/utils";
 import { createProxy } from "./build/proxy";
 import { viteMockServe } from "vite-plugin-mock";
 import svgLoader from "vite-svg-loader";
@@ -13,8 +13,6 @@ const pathResolve = (dir: string): any => {
   return resolve(__dirname, ".", dir);
 };
 
-const { VITE_PORT, VITE_PUBLIC_PATH, VITE_PROXY } = loadEnv();
-
 const alias: Record<string, string> = {
   "/@": pathResolve("src"),
   //解决开发环境下的警告 You are running the esm-bundler build of vue-i18n. It is recommended to configure your bundler to explicitly replace feature flag globals with boolean literals to get proper tree-shaking in the final bundle.
@@ -23,7 +21,10 @@ const alias: Record<string, string> = {
 
 const root: string = process.cwd();
 
-export default ({ command }: ConfigEnv): UserConfigExport => {
+export default ({ command, mode }: ConfigEnv): UserConfigExport => {
+  const { VITE_PORT, VITE_PUBLIC_PATH, VITE_PROXY } = warpperEnv(
+    loadEnv(mode, root)
+  );
   const prodMock = true;
   return {
     /**


### PR DESCRIPTION
自定义loadEnv函数，[process.env.NODE_ENV](https://github.com/xiaoxian521/vue-pure-admin/blob/main/build/utils.ts#L12)=undefined，并且采用[dotenv](https://github.com/motdotla/dotenv)组件包含node内置的[fs](https://github.com/motdotla/dotenv/blob/master/lib/main.js#L101) 是undefined,所以采用Vite loadEnv，并保留loadEnv自定义函数