### PR TITLE
fix: 修复动态路由子级长度为0时抛出异常

### DIFF
--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -230,16 +230,18 @@ function addAsyncRoutes(arrRoutes: Array<RouteRecordRaw>) {
     // 将backstage属性加入meta，标识此路由为后端返回路由
     v.meta.backstage = true;
     // 父级的redirect属性取值：如果子级存在且父级的redirect属性不存在，默认取第一个子级的path；如果子级存在且父级的redirect属性存在，取存在的redirect属性，会覆盖默认值
-    if (v?.children && !v.redirect) v.redirect = v.children[0].path;
+    if (v?.children && v.children.length && !v.redirect)
+      v.redirect = v.children[0].path;
     // 父级的name属性取值：如果子级存在且父级的name属性不存在，默认取第一个子级的name；如果子级存在且父级的name属性存在，取存在的name属性，会覆盖默认值
-    if (v?.children && !v.name) v.name = v.children[0].name;
+    if (v?.children && v.children.length && !v.name)
+      v.name = v.children[0].name;
     if (v.meta?.frameSrc) v.component = IFrame;
     // 对后端传component组件路径和不传做兼容（如果后端传component组件路径，那么path可以随便写，如果不传，component组件路径会跟path保持一致）
     const index = v?.component
       ? modulesRoutesKeys.findIndex(ev => ev.includes(v.component as any))
       : modulesRoutesKeys.findIndex(ev => ev.includes(v.path));
     v.component = modulesRoutes[modulesRoutesKeys[index]];
-    if (v.children) {
+    if (v?.children && v.children.length) {
       addAsyncRoutes(v.children);
     }
   });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5895634/186043011-4a8ba5e6-cfd0-4318-a67c-b424374a5111.png)
修复动态路由children为空数组时报错的Bug