### PR TITLE
chore(build): getPackageSize 的 folder 修改为动态从 vite 配置中获取

### DIFF
--- a/build/info.ts
+++ b/build/info.ts
@@ -9,10 +9,12 @@ export function viteBuildInfo(): Plugin {
   let config: { command: string };
   let startTime: Dayjs;
   let endTime: Dayjs;
+  let outDir: string;
   return {
     name: "vite:buildInfo",
-    configResolved(resolvedConfig: { command: string }) {
+    configResolved(resolvedConfig) {
       config = resolvedConfig;
+      outDir = resolvedConfig.build?.outDir ?? "dist";
     },
     buildStart() {
       console.log(
@@ -32,6 +34,7 @@ export function viteBuildInfo(): Plugin {
       if (config.command === "build") {
         endTime = dayjs(new Date());
         getPackageSize({
+          folder: outDir,
           callback: (size: string) => {
             console.log(
               bold(


### PR DESCRIPTION
当 vite.config.ts 的打包路径 build.outDir 不是默认值 dist 时, getPackageSize 方法会出错