### PR TITLE
fix: 兼容transition使用在无根元素组件时路由切换失败的问题

### DIFF
--- a/src/layout/components/appMain.vue
+++ b/src/layout/components/appMain.vue
@@ -85,42 +85,28 @@ const transitionMain = defineComponent({
             <backTop />
           </el-backtop>
           <transitionMain :route="route">
-            <keep-alive
-              v-if="keepAlive"
-              :include="usePermissionStoreHook().cachePageList"
-            >
-              <component
-                :is="Component"
-                :key="route.fullPath"
-                class="main-content"
-              />
-            </keep-alive>
-            <component
-              v-else
-              :is="Component"
-              :key="route.fullPath"
-              class="main-content"
-            />
+            <div :key="route.fullPath">
+              <keep-alive
+                v-if="keepAlive"
+                :include="usePermissionStoreHook().cachePageList"
+              >
+                <component :is="Component" class="m-6" />
+              </keep-alive>
+              <component v-else :is="Component" class="m-6" />
+            </div>
           </transitionMain>
         </el-scrollbar>
         <div v-else>
           <transitionMain :route="route">
-            <keep-alive
-              v-if="keepAlive"
-              :include="usePermissionStoreHook().cachePageList"
-            >
-              <component
-                :is="Component"
-                :key="route.fullPath"
-                class="main-content"
-              />
-            </keep-alive>
-            <component
-              v-else
-              :is="Component"
-              :key="route.fullPath"
-              class="main-content"
-            />
+            <div :key="route.fullPath">
+              <keep-alive
+                v-if="keepAlive"
+                :include="usePermissionStoreHook().cachePageList"
+              >
+                <component :is="Component" class="m-6" />
+              </keep-alive>
+              <component v-else :is="Component" class="m-6" />
+            </div>
           </transitionMain>
         </div>
       </template>

--- a/src/layout/components/appMain.vue
+++ b/src/layout/components/appMain.vue
@@ -90,9 +90,9 @@ const transitionMain = defineComponent({
                 v-if="keepAlive"
                 :include="usePermissionStoreHook().cachePageList"
               >
-                <component :is="Component" class="m-6" />
+                <component :is="Component" class="main-content" />
               </keep-alive>
-              <component v-else :is="Component" class="m-6" />
+              <component v-else :is="Component" class="main-content" />
             </div>
           </transitionMain>
         </el-scrollbar>
@@ -103,9 +103,9 @@ const transitionMain = defineComponent({
                 v-if="keepAlive"
                 :include="usePermissionStoreHook().cachePageList"
               >
-                <component :is="Component" class="m-6" />
+                <component :is="Component" class="main-content" />
               </keep-alive>
-              <component v-else :is="Component" class="m-6" />
+              <component v-else :is="Component" class="main-content" />
             </div>
           </transitionMain>
         </div>


### PR DESCRIPTION
问题：在协作开发时，可能有些组件没有根元素，Vue3 支持但 transition 不支持，这时候在页面切换的时候可能出现页面（appMain相关代码部分）空白的情况，路由无法正常跳转。
兼容办法：用一个div包裹transition的插槽组件component，并通过key绑定路由的路径。

:key=“route.fullPath”写在component上好像不生效，这里删除了，同时把class换成了Tailwind CSS写法