### PR TITLE
fix: 修复login.vue页面标签异常

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -21,7 +21,6 @@ import update from "./components/update.vue";
 import { initRouter } from "@/router/utils";
 import { useNav } from "@/layout/hooks/useNav";
 import type { FormInstance } from "element-plus";
-import { $t, transformI18n } from "@/plugins/i18n";
 import { operates, thirdParty } from "./utils/enums";
 import { useLayout } from "@/layout/hooks/useLayout";
 import { useUserStoreHook } from "@/store/modules/user";
@@ -174,16 +173,7 @@ watch(imgCode, value => {
             size="large"
           >
             <Motion :delay="100">
-              <el-form-item
-                :rules="[
-                  {
-                    required: true,
-                    message: transformI18n($t('login.usernameReg')),
-                    trigger: 'blur'
-                  }
-                ]"
-                prop="username"
-              >
+              <el-form-item prop="username">
                 <el-input
                   clearable
                   v-model="ruleForm.username"

--- a/src/views/login/utils/rule.ts
+++ b/src/views/login/utils/rule.ts
@@ -13,6 +13,13 @@ export const REGEXP_PWD =
 
 /** 登录校验 */
 const loginRules = reactive(<FormRules>{
+  username: [
+    {
+      required: true,
+      message: transformI18n($t("login.usernameReg")),
+      trigger: "blur"
+    }
+  ],
   password: [
     {
       validator: (rule, value, callback) => {


### PR DESCRIPTION
login.vue
177行：el-form-item标签rules属性导致下面标签<>异常
![image](https://user-images.githubusercontent.com/56647128/212360309-dad84a31-e367-4b05-8038-0aa692711e73.png)
