### PR TITLE
fix: 修复不同路由使用相同参数时，多个标签页会同时被激活的问题

### DIFF
--- a/src/layout/hooks/useTag.ts
+++ b/src/layout/hooks/useTag.ts
@@ -114,14 +114,21 @@ export function useTags() {
   ]);
 
   function conditionHandle(item, previous, next) {
+    const currentName = route.name || "";
+    const itemName = item.name || "";
+
     if (isBoolean(route?.meta?.showLink) && route?.meta?.showLink === false) {
       if (Object.keys(route.query).length > 0) {
-        return isEqual(route.query, item.query) ? previous : next;
+        return currentName === itemName && isEqual(route.query, item.query)
+          ? previous
+          : next;
       } else {
-        return isEqual(route.params, item.params) ? previous : next;
+        return currentName === itemName && isEqual(route.params, item.params)
+          ? previous
+          : next;
       }
     } else {
-      return route.path === item.path ? previous : next;
+      return currentName === itemName ? previous : next;
     }
   }
 

--- a/src/store/modules/multiTags.ts
+++ b/src/store/modules/multiTags.ts
@@ -80,22 +80,15 @@ export const useMultiTagsStore = defineStore("pure-multiTags", {
             if (isBoolean(tagVal?.meta?.showLink) && !tagVal?.meta?.showLink)
               return;
             const tagPath = tagVal.path;
-            // 判断tag是否已存在
             const tagHasExits = this.multiTags.some(tag => {
-              return tag.path === tagPath;
+              return (
+                tag.path === tagPath &&
+                isEqual(tag?.query, tagVal?.query) &&
+                isEqual(tag?.params, tagVal?.params)
+              );
             });
 
-            // 判断tag中的query键值是否相等
-            const tagQueryHasExits = this.multiTags.some(tag => {
-              return isEqual(tag?.query, tagVal?.query);
-            });
-
-            // 判断tag中的params键值是否相等
-            const tagParamsHasExits = this.multiTags.some(tag => {
-              return isEqual(tag?.params, tagVal?.params);
-            });
-
-            if (tagHasExits && tagQueryHasExits && tagParamsHasExits) return;
+            if (tagHasExits) return;
 
             // 动态路由可打开的最大数量
             const dynamicLevel = tagVal?.meta?.dynamicLevel ?? -1;


### PR DESCRIPTION
## 温馨提示：
### 从反馈该问题的朋友提供的`demo`来看，请不要对 [src/views/tabs/hooks.ts](https://github.com/pure-admin/vue-pure-admin/blob/main/src/views/tabs/hooks.ts)  文件进行语法再精简。有时候，问题恰恰出在那些看似简洁但未经充分测试的代码上。应先按照平台原有的写法实现功能，确保运行稳定后再考虑优化和精简。平台需要考虑代码易读性，因此不会去深度精简。