### PR TITLE
feat: 添加 usePageHeight hook 解决当无法约束子元素溢出的问题

### DIFF
--- a/src/layout/hooks/usePageHeight.ts
+++ b/src/layout/hooks/usePageHeight.ts
@@ -1,0 +1,38 @@
+import { computed } from "vue";
+
+import { useGlobal } from "@pureadmin/utils";
+import { useTags } from "@/layout/hooks/useTag";
+
+const NAVBAR_HEIGHT = 48; // 顶部导航栏高度
+const TAGS_HEIGHT_CHROME = 38; // Chrome 模式标签页高度
+const TAGS_HEIGHT_DEFAULT = 34; // 默认标签页高度
+const FOOTER_HEIGHT = 32; // 页脚高度
+
+/**
+ * 获取当前页面内容区的可用高度
+ */
+export function usePageHeight() {
+  const { $storage } = useGlobal<GlobalPropertiesApi>();
+  const { showModel } = useTags();
+
+  const hideTabs = computed(() => $storage?.configure.hideTabs);
+  const hideFooter = computed(() => $storage?.configure.hideFooter);
+
+  const tagsHeight = computed(() => {
+    if (hideTabs.value) return 0;
+    return showModel.value === "chrome"
+      ? TAGS_HEIGHT_CHROME
+      : TAGS_HEIGHT_DEFAULT;
+  });
+
+  const footerHeight = computed(() => {
+    return hideFooter.value ? 0 : FOOTER_HEIGHT;
+  });
+
+  const pageHeight = computed(() => {
+    const offset = NAVBAR_HEIGHT + tagsHeight.value + footerHeight.value;
+    return `calc(100vh - ${offset}px)`;
+  });
+
+  return pageHeight;
+}


### PR DESCRIPTION
在做数据列表页面的时候，我想实现这样的效果：

- **搜索框**和**表格标题**固定在顶部，不滚动
- **表格内容**有 100 条数据时，只让表格内部滚动
- **分页器**固定在底部，不滚动
- **不要整页滚动**（滚动时顶部导航栏、搜索框都不会被滚走）

但是发现一个问题：虽然h-full能获取当前页面高度，但是当前layout下无法防止页面内容溢出。

```vue
<!--  这样写不起作用 -->
<div class="h-full overflow-hide">
  <el-table height="100%">...</el-table>
</div>
```

创建了一个 `usePageHeight` hook，它会自动计算出页面内容区的实际可用高度。


在组件中使用：

```vue
<script setup>
import { usePageHeight } from "@/layout/hooks/usePageHeight";

const pageHeight = usePageHeight();
</script>

<template>
  <div :style="{ height: pageHeight }" class="flex flex-col">
    <!-- 固定部分：搜索表单 -->
    <div class="shrink-0">
      <SearchForm />
    </div>
    
    <!-- 滚动部分：表格 -->
    <div class="flex-1 overflow-hidden">
      <el-table height="100%" :data="tableData">
        <!-- 100 条数据，只在表格内部滚动 -->
      </el-table>
    </div>
    
    <!-- 固定部分：分页器 -->
    <div class="shrink-0">
      <el-pagination />
    </div>
  </div>
</template>
```
