### PR TITLE
style: 调整Chrome风格下，Tab页签之间的竖线显示样式

### DIFF
--- a/src/layout/components/lay-tag/index.scss
+++ b/src/layout/components/lay-tag/index.scss
@@ -324,7 +324,6 @@
     left: 7px;
     width: 1px;
     height: 14px;
-    background-color: #e2e2e5;
   }
 
   &:hover {

--- a/src/layout/components/lay-tag/index.vue
+++ b/src/layout/components/lay-tag/index.vue
@@ -620,7 +620,7 @@ onBeforeUnmount(() => {
           <div v-else class="chrome-tab">
             <span
               v-if="index !== 0 && index !== activeIndex"
-              class="chrome-tab-divider"
+              class="chrome-tab-divider bg-[#e2e2e2] dark:bg-[#2d2d2d]"
             />
             <div class="chrome-tab__bg">
               <TagChrome />


### PR DESCRIPTION
1、调整Tab页签中间的“|”分隔颜色，原本颜色太深比较突兀。
2、调整“|”分隔符的位置，避免最后一个Tab页签后还会显示“|”分隔，有点冗余。