### PR TITLE
feat: 刷新`token`接口请求失败后，跳转到登录页面，需重新登录

### DIFF
--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -239,6 +239,7 @@ login:
   purePassWordSureReg: Please enter confirm password
   purePassWordDifferentReg: The two passwords do not match!
   purePassWordUpdateReg: Password has been updated
+  pureLoginExpired: Login expired, please login again
 tableBar:
   pureList: List
   pureLarge: Large

--- a/locales/zh-CN.yaml
+++ b/locales/zh-CN.yaml
@@ -239,6 +239,7 @@ login:
   purePassWordSureReg: 请输入确认密码
   purePassWordDifferentReg: 两次密码不一致!
   purePassWordUpdateReg: 修改密码成功
+  pureLoginExpired: 登录已过期，请重新登录
 tableBar:
   pureList: 列表
   pureLarge: 宽松

--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -10,6 +10,8 @@ import type {
   PureHttpRequestConfig
 } from "./types.d";
 import { stringify } from "qs";
+import { message } from "@/utils/message";
+import { $t, transformI18n } from "@/plugins/i18n";
 import { getToken, formatToken } from "@/utils/auth";
 import { useUserStoreHook } from "@/store/modules/user";
 
@@ -91,7 +93,11 @@ class PureHttp {
                         PureHttp.requests = [];
                       })
                       .catch(_err => {
+                        PureHttp.requests = [];
                         useUserStoreHook().logOut();
+                        message(transformI18n($t("login.pureLoginExpired")), {
+                          type: "warning"
+                        });
                       })
                       .finally(() => {
                         PureHttp.isRefreshing = false;


### PR DESCRIPTION
调用refresh-token接口失败可能有几种原因：
1. refreshToken失效
2. 网络错误
3. 后端错误

无论是哪种情况，都需要重新登陆